### PR TITLE
Chore: add error logger 

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,11 +30,11 @@ type CorsConfig struct {
 
 type Server struct {
 	config Config
-	App    *fiber.App
-	DB     *database.Store
+	app    *fiber.App
+	db     *database.Store
 }
 
-func New(config Config, corsConfig CorsConfig, DB *database.Store) *Server {
+func New(config Config, corsConfig CorsConfig, db *database.Store) *Server {
 	app := fiber.New(fiber.Config{
 		AppName:       config.Name,
 		BodyLimit:     config.MaxBodyLimit * 1024 * 1024,
@@ -58,27 +58,27 @@ func New(config Config, corsConfig CorsConfig, DB *database.Store) *Server {
 
 	return &Server{
 		config: config,
-		App:    app,
-		DB:     DB,
+		app:    app,
+		db:     db,
 	}
 }
 
 func (s *Server) Start(ctx context.Context, stop context.CancelFunc) {
-	s.App.Get("/v1/", func(c *fiber.Ctx) error {
+	s.app.Get("/v1/", func(c *fiber.Ctx) error {
 		return c.JSON(dto.HttpResponse{
 			Result: "ok",
 		})
 	})
 
 	go func() {
-		if err := s.App.Listen(fmt.Sprintf(":%d", s.config.Port)); err != nil {
+		if err := s.app.Listen(fmt.Sprintf(":%d", s.config.Port)); err != nil {
 			logger.PanicContext(ctx, "failed to start server", slog.Any("error", err))
 			stop()
 		}
 	}()
 
 	defer func() {
-		if err := s.App.ShutdownWithContext(ctx); err != nil {
+		if err := s.app.ShutdownWithContext(ctx); err != nil {
 			logger.ErrorContext(ctx, "failed to shutdown server", slog.Any("error", err))
 		}
 		logger.InfoContext(ctx, "gracefully shutdown server")

--- a/pkg/apperror/apperror.go
+++ b/pkg/apperror/apperror.go
@@ -1,0 +1,42 @@
+package apperror
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type ErrorType string
+
+type AppError struct {
+	Code    int
+	Message string
+	Err     error
+}
+
+func (e *AppError) Error() string {
+	return e.Err.Error()
+}
+
+func New(code int, msg string, err error) *AppError {
+	return &AppError{
+		Code:    code,
+		Message: msg,
+		Err:     fmt.Errorf("%s: %v", msg, err),
+	}
+}
+
+func Internal(msg string, err error) *AppError {
+	return New(http.StatusInternalServerError, msg, err)
+}
+
+func BadRequest(msg string, err error) *AppError {
+	return New(http.StatusBadRequest, msg, err)
+}
+
+func NotFound(msg string, err error) *AppError {
+	return New(http.StatusNotFound, msg, err)
+}
+
+func UnAuthorized(msg string, err error) *AppError {
+	return New(http.StatusUnauthorized, msg, err)
+}

--- a/pkg/apperror/apperror.go
+++ b/pkg/apperror/apperror.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 )
 
-type ErrorType string
-
 type AppError struct {
 	Code    int
 	Message string

--- a/pkg/requestlogger/requestlogger.go
+++ b/pkg/requestlogger/requestlogger.go
@@ -1,8 +1,11 @@
 package requestlogger
 
 import (
+	"errors"
 	"log/slog"
 
+	"github.com/CP-RektMart/pic-me-pls-backend/internal/dto"
+	"github.com/CP-RektMart/pic-me-pls-backend/pkg/apperror"
 	"github.com/CP-RektMart/pic-me-pls-backend/pkg/logger"
 	"github.com/gofiber/fiber/v2"
 )
@@ -10,7 +13,34 @@ import (
 func New() func(ctx *fiber.Ctx) error {
 	return func(ctx *fiber.Ctx) error {
 		requestId := ctx.GetRespHeader("X-Request-Id")
-		logger.InfoContext(ctx.UserContext(), "request received", slog.String("request_id", requestId), slog.String("method", ctx.Method()), slog.String("path", ctx.Path()))
-		return ctx.Next()
+		err := ctx.Next()
+		if err != nil {
+			return handleError(ctx, err)
+		}
+
+		logger.InfoContext(ctx.UserContext(), "request received", slog.String("request_id", requestId), slog.String("method", ctx.Method()), slog.String("path", ctx.Path()), slog.Int("status", ctx.Response().StatusCode()))
+		return nil
 	}
+}
+
+func handleError(c *fiber.Ctx, err error) error {
+	var fiberError *fiber.Error
+	if errors.As(err, &fiberError) {
+		c.Set(fiber.HeaderContentType, fiber.MIMETextPlainCharsetUTF8)
+		return c.Status(fiberError.Code).SendString(fiberError.Message)
+	}
+
+	status := fiber.StatusInternalServerError
+	message := "internal server error"
+
+	var appError *apperror.AppError
+	if errors.As(err, &appError) {
+		status = appError.Code
+		message = appError.Message
+	}
+
+	logger.ErrorContext(c.UserContext(), "Request Error", slog.Int("status", status), slog.Any("error", err))
+	return c.Status(status).JSON(dto.HttpResponse{
+		Error: message,
+	})
 }

--- a/pkg/requestlogger/requestlogger.go
+++ b/pkg/requestlogger/requestlogger.go
@@ -15,7 +15,7 @@ func New() func(ctx *fiber.Ctx) error {
 		requestId := ctx.GetRespHeader("X-Request-Id")
 		err := ctx.Next()
 		if err != nil {
-			return handleError(ctx, err)
+			return handleError(ctx, err, requestId)
 		}
 
 		logger.InfoContext(ctx.UserContext(), "request received", slog.String("request_id", requestId), slog.String("method", ctx.Method()), slog.String("path", ctx.Path()), slog.Int("status", ctx.Response().StatusCode()))
@@ -23,7 +23,7 @@ func New() func(ctx *fiber.Ctx) error {
 	}
 }
 
-func handleError(c *fiber.Ctx, err error) error {
+func handleError(c *fiber.Ctx, err error, requestId string) error {
 	var fiberError *fiber.Error
 	if errors.As(err, &fiberError) {
 		c.Set(fiber.HeaderContentType, fiber.MIMETextPlainCharsetUTF8)
@@ -39,7 +39,7 @@ func handleError(c *fiber.Ctx, err error) error {
 		message = appError.Message
 	}
 
-	logger.ErrorContext(c.UserContext(), "Request Error", slog.Int("status", status), slog.Any("error", err))
+	logger.ErrorContext(c.UserContext(), "Request Error", slog.String("request_id", requestId), slog.String("method", c.Method()), slog.String("path", c.Path()), slog.Int("status", status), slog.Any("error", err))
 	return c.Status(status).JSON(dto.HttpResponse{
 		Error: message,
 	})


### PR DESCRIPTION
## Changes
- Add `apperror` package 
- Add error logger to requestLogger middleware

### Add `apperror` package 
`apperror` is the error struct type that contain public error message for sending back to client and internal error message for logging
```go
type AppError struct {
	Code    int
	Message string
	Err     error
}
```
how to use:
It have constructor for different type of error eg. `internal error (500)` `badrequest (400)` etc..
so just return it in controller
```go
func (s *server) handlerSomthing(c *fiber.Ctx) error {
      
err := s.db.getUserByEmail(c, email)
      return apperror.BadRequest("email not found", err)
}

```

### Add error logger to requestLogger middleware
This will receive error from controller and response the status and public message
