### PR TITLE
fix quotation response

### DIFF
--- a/internal/services/quotation/list-quotations.go
+++ b/internal/services/quotation/list-quotations.go
@@ -47,8 +47,11 @@ func (h *Handler) HandleListQuotations(c *fiber.Ctx) error {
 		return err
 	}
 
-	return c.Status(fiber.StatusOK).JSON(dto.HttpResponse[dto.PaginationResponse[dto.QuotationResponse]]{
-		Result: *quotations,
+	return c.Status(fiber.StatusOK).JSON(dto.PaginationResponse[dto.QuotationResponse]{
+		Page:      quotations.Page,
+		PageSize:  quotations.PageSize,
+		TotalPage: quotations.TotalPage,
+		Data:      quotations.Data,
 	})
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/292a9200-8ec6-459d-a1ed-53e7cef9a5a0)
![image](https://github.com/user-attachments/assets/dd77293a-34b9-4b36-964b-9e41bfe05708)

I found that return should not have dto.HttpResponse for dto.PaginationResponse[dto.QuotationResponse] 
That dont match in swagger 
return type not match, cause openapi break 